### PR TITLE
Example and warning cleanup

### DIFF
--- a/Components/Hackable.cs
+++ b/Components/Hackable.cs
@@ -16,7 +16,7 @@ namespace NobleMuffins.LimbHacker
 
         public InfillMode infillMode = InfillMode.Sloppy;
 
-        private bool destructionPending = false;
+        protected bool destructionPending = false;
 
         void Start()
         {

--- a/Example/AttachableSlicerController.cs
+++ b/Example/AttachableSlicerController.cs
@@ -1,18 +1,21 @@
 ﻿using UnityEngine;
 
-[RequireComponent(typeof(SwordVelocityFilter))]
-public class AttachableSlicerController : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	private SwordVelocityFilter swordVelocityFilter;
-	public GameObject slicer;
-	
-	void Start ()
+	[RequireComponent(typeof(SwordVelocityFilter))]
+	public class AttachableSlicerController : MonoBehaviour
 	{
-		swordVelocityFilter = GetComponent<SwordVelocityFilter>();
-	}
+		private SwordVelocityFilter swordVelocityFilter;
+		public GameObject slicer;
 
-	void Update ()
-	{
-		slicer.SetActive( swordVelocityFilter.IsFastEnoughToCut );
+		void Start()
+		{
+			swordVelocityFilter = GetComponent<SwordVelocityFilter>();
+		}
+
+		void Update()
+		{
+			slicer.SetActive(swordVelocityFilter.IsFastEnoughToCut);
+		}
 	}
 }

--- a/Example/Button.cs
+++ b/Example/Button.cs
@@ -1,76 +1,79 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-[RequireComponent(typeof(Collider))]
-public class Button : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	const float changeTime = 0.033f;
-
-	public new Camera camera;
-
-	public GameObject target;
-	public string message;
-	
-	public AudioClip clickSound;
-
-	public bool visible;
-	
-	private new Transform transform;
-	private new Collider collider;
-	private Vector3 scaleAtStart;
-	
-	private float size = 1f, sizeDelta = 0f;
-	private bool pressedAsButton = false;
-	
-	void Start()
+	[RequireComponent(typeof(Collider))]
+	public class Button : MonoBehaviour
 	{
-		transform = GetComponent<Transform>();
-		collider = GetComponent<Collider>();
-		
-		scaleAtStart = transform.localScale;
-		
-		if(camera == null) camera = Camera.main;
-	}
+		const float changeTime = 0.033f;
 
-	private bool firstRun = true;
-	
-	void Update()
-	{
-		Ray ray = camera.ScreenPointToRay(Input.mousePosition);
-		
-		RaycastHit hitInfo;
-		
-		bool hover = collider.Raycast(ray, out hitInfo, 2f);
-		
-		pressedAsButton |= hover && Input.GetMouseButtonDown(0);
-		
-		bool released = Input.GetMouseButtonUp(0);
-		
-		bool releasedAsButton = pressedAsButton && hover && released;
-		
-		if(released)
+		public new Camera camera;
+
+		public GameObject target;
+		public string message;
+
+		public AudioClip clickSound;
+
+		public bool visible;
+
+		private new Transform transform;
+		private new Collider collider;
+		private Vector3 scaleAtStart;
+
+		private float size = 1f, sizeDelta = 0f;
+		private bool pressedAsButton = false;
+
+		void Start()
 		{
-			pressedAsButton = false;
+			transform = GetComponent<Transform>();
+			collider = GetComponent<Collider>();
+
+			scaleAtStart = transform.localScale;
+
+			if (camera == null) camera = Camera.main;
 		}
-		
-		if(releasedAsButton)
-		{
-			target.SendMessage(message);
 
-			if(clickSound != null)
+		private bool firstRun = true;
+
+		void Update()
+		{
+			Ray ray = camera.ScreenPointToRay(Input.mousePosition);
+
+			RaycastHit hitInfo;
+
+			bool hover = collider.Raycast(ray, out hitInfo, 2f);
+
+			pressedAsButton |= hover && Input.GetMouseButtonDown(0);
+
+			bool released = Input.GetMouseButtonUp(0);
+
+			bool releasedAsButton = pressedAsButton && hover && released;
+
+			if (released)
 			{
-				AudioSource.PlayClipAtPoint(clickSound, Vector3.zero);
+				pressedAsButton = false;
 			}
+
+			if (releasedAsButton)
+			{
+				target.SendMessage(message);
+
+				if (clickSound != null)
+				{
+					AudioSource.PlayClipAtPoint(clickSound, Vector3.zero);
+				}
+			}
+
+			bool enlarge = hover || pressedAsButton;
+
+			float idealSize = (enlarge ? 1.1f : 1f) * (visible ? 1f : 0f);
+
+			size = firstRun ? idealSize : Mathf.SmoothDamp(size, idealSize, ref sizeDelta, changeTime);
+
+			firstRun = false;
+
+			transform.localScale = size * scaleAtStart;
 		}
-		
-		bool enlarge = hover || pressedAsButton;
-		
-		float idealSize = (enlarge ? 1.1f : 1f) * (visible ? 1f : 0f);
-
-		size = firstRun ? idealSize : Mathf.SmoothDamp(size, idealSize, ref sizeDelta, changeTime);
-
-		firstRun = false;
-		
-		transform.localScale = size * scaleAtStart;
 	}
 }

--- a/Example/CameraPositionController.cs
+++ b/Example/CameraPositionController.cs
@@ -1,28 +1,32 @@
 ﻿using UnityEngine;
 
-public class CameraPositionController : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	public Transform backAwayPosition, upClosePosition;
-	public TimeForSlicingFilter timeForSlicingFilter;
-	public float transitionTime = 1f;
-	
-	private new Transform transform;
-	private Vector3 position, positionDelta;	
-
-	// Use this for initialization
-	void Start () {
-		transform = GetComponent<Transform>();
-		
-		position = transform.position;
-	}
-	
-	// Update is called once per frame
-	void Update ()
+	public class CameraPositionController : MonoBehaviour
 	{
-		Vector3 idealPosition = timeForSlicingFilter.IsTimeForSlicing ? upClosePosition.position : backAwayPosition.position;
-		
-		position = Vector3.SmoothDamp(position, idealPosition, ref positionDelta, transitionTime);
-		
-		transform.position = position;
+		public Transform backAwayPosition, upClosePosition;
+		public TimeForSlicingFilter timeForSlicingFilter;
+		public float transitionTime = 1f;
+
+		private new Transform transform;
+		private Vector3 position, positionDelta;
+
+		// Use this for initialization
+		void Start()
+		{
+			transform = GetComponent<Transform>();
+
+			position = transform.position;
+		}
+
+		// Update is called once per frame
+		void Update()
+		{
+			Vector3 idealPosition = timeForSlicingFilter.IsTimeForSlicing ? upClosePosition.position : backAwayPosition.position;
+
+			position = Vector3.SmoothDamp(position, idealPosition, ref positionDelta, transitionTime);
+
+			transform.position = position;
+		}
 	}
 }

--- a/Example/CameraSteer.cs
+++ b/Example/CameraSteer.cs
@@ -1,45 +1,49 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class CameraSteer : MonoBehaviour {
-	
-	private Vector3 naturalForward, naturalUp, naturalRight;
-	
-	private Vector3 forward, forwardDelta;
-	
-	private new Transform transform;
-	
-	public float panSpeed = 0.33f;
-	
-	void Awake ()
+namespace NobleMuffins.LimbHacker.Examples
+{
+	public class CameraSteer : MonoBehaviour
 	{
-		transform = GetComponent<Transform>();
-		
-		naturalForward = transform.forward;
-		naturalRight = transform.right;
-		naturalUp = transform.up;
-		
-		forward = naturalForward;
-		forwardDelta = Vector3.zero;
-	}
-	
-	// Update is called once per frame
-	void Update ()
-	{
-		Vector2 center = new Vector2(Screen.width / 2f, Screen.height / 2f);
-		Vector2 current = (Vector2) Input.mousePosition;
-		
-		Vector2 delta = current - center;
-		
-		delta.x /= Screen.width;
-		delta.y /= Screen.height;
-		
-		delta *= 0.33f;
-		
-		Vector3 idealForward = (naturalForward + naturalRight * delta.x + naturalUp * delta.y).normalized;
-		
-		forward = Vector3.SmoothDamp(forward, idealForward, ref forwardDelta, panSpeed);
-		
-		transform.forward = forward;
+
+		private Vector3 naturalForward, naturalUp, naturalRight;
+
+		private Vector3 forward, forwardDelta;
+
+		private new Transform transform;
+
+		public float panSpeed = 0.33f;
+
+		void Awake()
+		{
+			transform = GetComponent<Transform>();
+
+			naturalForward = transform.forward;
+			naturalRight = transform.right;
+			naturalUp = transform.up;
+
+			forward = naturalForward;
+			forwardDelta = Vector3.zero;
+		}
+
+		// Update is called once per frame
+		void Update()
+		{
+			Vector2 center = new Vector2(Screen.width / 2f, Screen.height / 2f);
+			Vector2 current = (Vector2)Input.mousePosition;
+
+			Vector2 delta = current - center;
+
+			delta.x /= Screen.width;
+			delta.y /= Screen.height;
+
+			delta *= 0.33f;
+
+			Vector3 idealForward = (naturalForward + naturalRight * delta.x + naturalUp * delta.y).normalized;
+
+			forward = Vector3.SmoothDamp(forward, idealForward, ref forwardDelta, panSpeed);
+
+			transform.forward = forward;
+		}
 	}
 }

--- a/Example/MarkOfCain.cs
+++ b/Example/MarkOfCain.cs
@@ -1,22 +1,25 @@
 ﻿using UnityEngine;
 using System.Collections.Generic;
 
-public class MarkOfCain : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	private readonly static List<GameObject> markedObjects = new List<GameObject>();
-	
-	void Start()
+	public class MarkOfCain : MonoBehaviour
 	{
-		markedObjects.Add(gameObject);
-	}
-	
-	public static void DestroyAllMarkedObjects()
-	{
-		foreach(var go in markedObjects)
+		private readonly static List<GameObject> markedObjects = new List<GameObject>();
+
+		void Start()
 		{
-			if(go != null) Destroy(go);
+			markedObjects.Add(gameObject);
 		}
-		
-		markedObjects.Clear();
+
+		public static void DestroyAllMarkedObjects()
+		{
+			foreach (var go in markedObjects)
+			{
+				if (go != null) Destroy(go);
+			}
+
+			markedObjects.Clear();
+		}
 	}
 }

--- a/Example/RestartButton.cs
+++ b/Example/RestartButton.cs
@@ -1,22 +1,28 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-[RequireComponent(typeof(Button))]
-public class RestartButton : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	public Spawner spawner;
+	[RequireComponent(typeof(Button))]
+	public class RestartButton : MonoBehaviour
+	{
+		public Spawner spawner;
 
-	private Button button;
+		private Button button;
 
-	void Start() {
-		button = gameObject.GetComponent<Button>();
-	}
+		void Start()
+		{
+			button = gameObject.GetComponent<Button>();
+		}
 
-	void Update () {
-		button.visible = spawner.CanInstantiate;
-	}
+		void Update()
+		{
+			button.visible = spawner.CanInstantiate;
+		}
 
-	void OnClick() {
-		spawner.Instantiate();
+		void OnClick()
+		{
+			spawner.Instantiate();
+		}
 	}
 }

--- a/Example/Spawner.cs
+++ b/Example/Spawner.cs
@@ -1,40 +1,45 @@
 ﻿using UnityEngine;
 
-public class Spawner : MonoBehaviour {
-	
-	public GameObject puppet;
-	
-	public Object prefab;
-	
-	public System.Action<GameObject> instantiationListeners;
-	
-	public GUISkin skin;
+namespace NobleMuffins.LimbHacker.Examples
+{
+	public class Spawner : MonoBehaviour
+	{
 
-	// Use this for initialization
-	void Start ()
-	{
-		Instantiate();
-	}
-	
-	public void Instantiate()
-	{
-		if(CanInstantiate)
+		public GameObject puppet;
+
+		public Object prefab;
+
+		public System.Action<GameObject> instantiationListeners;
+
+		public GUISkin skin;
+
+		// Use this for initialization
+		void Start()
 		{
-			MarkOfCain.DestroyAllMarkedObjects();
-			
-			if(puppet == null)
-			{
-				puppet = GameObject.Instantiate(prefab, transform.position, transform.rotation) as GameObject;
-			}
-			
-			instantiationListeners(puppet);
+			Instantiate();
 		}
-	}
 
-	public bool CanInstantiate
-	{
-		get {
-			return puppet == null;
+		public void Instantiate()
+		{
+			if (CanInstantiate)
+			{
+				MarkOfCain.DestroyAllMarkedObjects();
+
+				if (puppet == null)
+				{
+					puppet = GameObject.Instantiate(prefab, transform.position, transform.rotation) as GameObject;
+				}
+
+				instantiationListeners(puppet);
+			}
+		}
+
+		public bool CanInstantiate
+		{
+			get
+			{
+				return puppet == null;
+			}
 		}
 	}
 }

--- a/Example/SwordTransformController.cs
+++ b/Example/SwordTransformController.cs
@@ -1,69 +1,74 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class SwordTransformController : MonoBehaviour {
-	
-	// Rotation order is YXZ
-	
-	private new Transform transform;
-	private Transform cameraTransform;
-	
-	public new Camera camera;
-	
-	private Vector3 idealForward = Vector3.forward;
-	private Vector3 forward = Vector3.forward;
-	private Vector3 forwardVelocity = Vector3.zero;
-	
-	private Vector3 idealUp = Vector3.up;
-	private Vector3 up = Vector3.up;
-	private Vector3 upVelocity = Vector3.zero;
-	
-	public float trackingTime = 0.1f;
-	
-	public float deadzone = 5f;
-	
-	public float reach = 3f;
-	
-	private Vector3 previousMousePosition = Vector3.zero;
-		
-	// Use this for initialization
-	void Start () {
-		transform = GetComponent<Transform>();
-		
-		if(camera == null)
-		{
-			Debug.LogError("TSD3SwordTransformController requires a camera to orient the sword.");
-			enabled = false;
-		}
-		else
-		{
-			cameraTransform = camera.transform;
-		}
-	}
-	
-	// Update is called once per frame
-	void Update ()
+namespace NobleMuffins.LimbHacker.Examples
+{
+	public class SwordTransformController : MonoBehaviour
 	{
-		Vector3 mousePosition = Input.mousePosition;
-		
-		Vector3 mouseDelta = previousMousePosition - mousePosition;
-		
-		if(mouseDelta.magnitude > deadzone)
+
+		// Rotation order is YXZ
+
+		private new Transform transform;
+		private Transform cameraTransform;
+
+		public new Camera camera;
+
+		private Vector3 idealForward = Vector3.forward;
+		private Vector3 forward = Vector3.forward;
+		private Vector3 forwardVelocity = Vector3.zero;
+
+		private Vector3 idealUp = Vector3.up;
+		private Vector3 up = Vector3.up;
+		private Vector3 upVelocity = Vector3.zero;
+
+		public float trackingTime = 0.1f;
+
+		public float deadzone = 5f;
+
+		public float reach = 3f;
+
+		private Vector3 previousMousePosition = Vector3.zero;
+
+		// Use this for initialization
+		void Start()
 		{
-			Vector3 cursorInThreeSpace = mousePosition;	
-			cursorInThreeSpace.z = reach;
-					
-			idealForward = (camera.ScreenToWorldPoint(cursorInThreeSpace) - transform.position).normalized;
-			
-			Matrix4x4 cameraLocalToWorld = cameraTransform.localToWorldMatrix;
-			
-			idealUp = cameraLocalToWorld.MultiplyVector(previousMousePosition - mousePosition).normalized;
-			
-			previousMousePosition = mousePosition;
+			transform = GetComponent<Transform>();
+
+			if (camera == null)
+			{
+				Debug.LogError("TSD3SwordTransformController requires a camera to orient the sword.");
+				enabled = false;
+			}
+			else
+			{
+				cameraTransform = camera.transform;
+			}
 		}
-		
-		forward = Vector3.SmoothDamp(forward, idealForward, ref forwardVelocity, trackingTime);
-		up = Vector3.SmoothDamp(up, idealUp, ref upVelocity, trackingTime);
-		transform.rotation = Quaternion.LookRotation(forward, up);
+
+		// Update is called once per frame
+		void Update()
+		{
+			Vector3 mousePosition = Input.mousePosition;
+
+			Vector3 mouseDelta = previousMousePosition - mousePosition;
+
+			if (mouseDelta.magnitude > deadzone)
+			{
+				Vector3 cursorInThreeSpace = mousePosition;
+				cursorInThreeSpace.z = reach;
+
+				idealForward = (camera.ScreenToWorldPoint(cursorInThreeSpace) - transform.position).normalized;
+
+				Matrix4x4 cameraLocalToWorld = cameraTransform.localToWorldMatrix;
+
+				idealUp = cameraLocalToWorld.MultiplyVector(previousMousePosition - mousePosition).normalized;
+
+				previousMousePosition = mousePosition;
+			}
+
+			forward = Vector3.SmoothDamp(forward, idealForward, ref forwardVelocity, trackingTime);
+			up = Vector3.SmoothDamp(up, idealUp, ref upVelocity, trackingTime);
+			transform.rotation = Quaternion.LookRotation(forward, up);
+		}
 	}
 }

--- a/Example/SwordVelocityFilter.cs
+++ b/Example/SwordVelocityFilter.cs
@@ -1,44 +1,49 @@
 ﻿using UnityEngine;
 
-public class SwordVelocityFilter : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	public float tipSpeedForCutting = 1f;
-	public float lengthInWorldUnits = 5f;
-	
-	private new Transform transform;
-	
-	void Start()
+	public class SwordVelocityFilter : MonoBehaviour
 	{
-		transform = GetComponent<Transform>();
-		
-		priorTipPositionInWorldSpace = deriveTipPosition();
-	}
-	
-	private Vector3 priorTipPositionInWorldSpace;
-	
-	private bool _IsFastEnoughToCut = false;	
-	public bool IsFastEnoughToCut {
-		get {
-			return _IsFastEnoughToCut;
+		public float tipSpeedForCutting = 1f;
+		public float lengthInWorldUnits = 5f;
+
+		private new Transform transform;
+
+		void Start()
+		{
+			transform = GetComponent<Transform>();
+
+			priorTipPositionInWorldSpace = deriveTipPosition();
 		}
-	}
-	
-	private Vector3 deriveTipPosition()
-	{
-		return transform.localToWorldMatrix.MultiplyPoint3x4( Vector3.forward * lengthInWorldUnits );
-	}
-	
-	// Update is called once per frame
-	void Update ()
-	{
-		Vector3 tipPositionInWorldSpace = deriveTipPosition();
-		
-		Vector3 tipDelta = tipPositionInWorldSpace - priorTipPositionInWorldSpace;
-		
-		float tipSpeed = tipDelta.magnitude / Time.deltaTime;
-		
-		_IsFastEnoughToCut = tipSpeed > tipSpeedForCutting;
-		
-		priorTipPositionInWorldSpace = tipPositionInWorldSpace;
+
+		private Vector3 priorTipPositionInWorldSpace;
+
+		private bool _IsFastEnoughToCut = false;
+		public bool IsFastEnoughToCut
+		{
+			get
+			{
+				return _IsFastEnoughToCut;
+			}
+		}
+
+		private Vector3 deriveTipPosition()
+		{
+			return transform.localToWorldMatrix.MultiplyPoint3x4(Vector3.forward * lengthInWorldUnits);
+		}
+
+		// Update is called once per frame
+		void Update()
+		{
+			Vector3 tipPositionInWorldSpace = deriveTipPosition();
+
+			Vector3 tipDelta = tipPositionInWorldSpace - priorTipPositionInWorldSpace;
+
+			float tipSpeed = tipDelta.magnitude / Time.deltaTime;
+
+			_IsFastEnoughToCut = tipSpeed > tipSpeedForCutting;
+
+			priorTipPositionInWorldSpace = tipPositionInWorldSpace;
+		}
 	}
 }

--- a/Example/TimeForSlicingFilter.cs
+++ b/Example/TimeForSlicingFilter.cs
@@ -28,7 +28,7 @@ namespace NobleMuffins.LimbHacker.Examples
 			{
 				if (Input.GetKey(KeyCode.A)) return true;
 				if (isAlwaysTimeForSlicing) return true;
-#if UNITY_5
+#if UNITY_5 || UNITY_5_3_OR_NEWER //Starting with 5.3 we can use UNITY_X_Y_OR_NEWER
 				return animator != null && animator.GetCurrentAnimatorStateInfo(0).fullPathHash == Animator.StringToHash(nameOfAnimationStateForSlicing);
 #else
 				return animator != null && animator.GetCurrentAnimatorStateInfo(0).nameHash == Animator.StringToHash(nameOfAnimationStateForSlicing);

--- a/Example/TimeForSlicingFilter.cs
+++ b/Example/TimeForSlicingFilter.cs
@@ -1,35 +1,39 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class TimeForSlicingFilter : MonoBehaviour
+namespace NobleMuffins.LimbHacker.Examples
 {
-	public string nameOfAnimationStateForSlicing = "Standing";
-	public Spawner spawner;
-
-    public bool isAlwaysTimeForSlicing;
-
-	private Animator animator;
-	
-	void Awake()
+	public class TimeForSlicingFilter : MonoBehaviour
 	{
-		spawner.instantiationListeners += HandleInstantiation;
-	}
-	
-	void HandleInstantiation(GameObject go)
-	{	
-		animator = go.GetComponent<Animator>();
-	}
-	
-	public bool IsTimeForSlicing {
-		get {
-			if(Input.GetKey(KeyCode.A)) return true;
-            if (isAlwaysTimeForSlicing) return true;
-			#if UNITY_5
-			return animator != null && animator.GetCurrentAnimatorStateInfo(0).fullPathHash == Animator.StringToHash(nameOfAnimationStateForSlicing);
-			#else
-			return animator != null && animator.GetCurrentAnimatorStateInfo(0).nameHash == Animator.StringToHash(nameOfAnimationStateForSlicing);
-			#endif
+		public string nameOfAnimationStateForSlicing = "Standing";
+		public Spawner spawner;
+
+		public bool isAlwaysTimeForSlicing;
+
+		private Animator animator;
+
+		void Awake()
+		{
+			spawner.instantiationListeners += HandleInstantiation;
+		}
+
+		void HandleInstantiation(GameObject go)
+		{
+			animator = go.GetComponent<Animator>();
+		}
+
+		public bool IsTimeForSlicing
+		{
+			get
+			{
+				if (Input.GetKey(KeyCode.A)) return true;
+				if (isAlwaysTimeForSlicing) return true;
+#if UNITY_5
+				return animator != null && animator.GetCurrentAnimatorStateInfo(0).fullPathHash == Animator.StringToHash(nameOfAnimationStateForSlicing);
+#else
+				return animator != null && animator.GetCurrentAnimatorStateInfo(0).nameHash == Animator.StringToHash(nameOfAnimationStateForSlicing);
+#endif
+			}
 		}
 	}
-	
 }

--- a/Guts/ChildOfHackable.cs
+++ b/Guts/ChildOfHackable.cs
@@ -21,7 +21,8 @@ namespace NobleMuffins.LimbHacker.Guts
         {
             parentHackable.Slice(positionInWorldSpace, normalInWorldSpace);
         }
-
+#pragma warning disable 0067
         public event EventHandler<SliceEventArgs> Sliced;
+#pragma warning restore 0067
     }
 }


### PR DESCRIPTION
I put all the example scripts in their own namespace "NobleMuffins.LimbHacker.Examples".  A lot of their class names conflict with Unity class names.

There were two warnings that I fixed too.  The "unused" event, I add a pragma to disable that warning and an additional compiler directive for newer Unity versions for the "animator.GetCurrentAnimatorStateInfo(0).fullPathHash"

Lastly, I made destructionPending protected instead of private so we could inherit from hackable for an UMA integration.